### PR TITLE
set run triggers in secondary workspaces for faster failover

### DIFF
--- a/cmd/cli/multiregion/setup.go
+++ b/cmd/cli/multiregion/setup.go
@@ -45,7 +45,7 @@ func runSetup() {
 
 	err := setRunTriggers(pFlags)
 	if err != nil {
-		log.Fatalf("Error: " + err.Error())
+		log.Fatalf("Error: %s", err)
 	}
 }
 

--- a/cmd/cli/multiregion/setup.go
+++ b/cmd/cli/multiregion/setup.go
@@ -42,6 +42,11 @@ func runSetup() {
 			log.Fatalf("Error: " + err.Error())
 		}
 	}
+
+	err := setRunTriggers(pFlags)
+	if err != nil {
+		log.Fatalf("Error: " + err.Error())
+	}
 }
 
 // createSecondaryWorkspaces creates new secondary workspaces by cloning the corresponding primary workspace
@@ -458,4 +463,62 @@ func getWorkspaceID(org, workspaceName string) (string, error) {
 		return "", fmt.Errorf("failed to get workspace data: %w", err)
 	}
 	return data.Data.ID, nil
+}
+
+func setRunTriggers(pFlags PersistentFlags) error {
+	fmt.Println("\nSetting workspace run triggers ...")
+
+	// map of workspaces (key) and source workspaces (value) for run triggers to be created
+	runTriggers := map[string]string{
+		databaseSecondaryWorkspace(pFlags): clusterSecondaryWorkspace(pFlags),
+		emailSecondaryWorkspace(pFlags):    databaseSecondaryWorkspace(pFlags),
+		brokerSecondaryWorkspace(pFlags):   emailSecondaryWorkspace(pFlags),
+		pwSecondaryWorkspace(pFlags):       brokerSecondaryWorkspace(pFlags),
+		sspSecondaryWorkspace(pFlags):      pwSecondaryWorkspace(pFlags),
+		syncSecondaryWorkspace(pFlags):     sspSecondaryWorkspace(pFlags),
+	}
+
+	for workspace, source := range runTriggers {
+		if err := createRunTrigger(pFlags, workspace, source); err != nil {
+			return fmt.Errorf("failed to set run trigger from %s to %s: %w", source, workspace, err)
+		}
+	}
+	return nil
+}
+
+func createRunTrigger(pFlags PersistentFlags, workspaceName, sourceName string) error {
+	workspaceID, err := getWorkspaceID(pFlags.org, workspaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get workspace ID for run trigger: %w", err)
+	}
+
+	sourceID, err := getWorkspaceID(pFlags.org, sourceName)
+	if err != nil {
+		return fmt.Errorf("failed to get source workspace ID for run trigger: %w", err)
+	}
+
+	t, err := lib.FindRunTrigger(lib.FindRunTriggerConfig{
+		WorkspaceID:       workspaceID,
+		SourceWorkspaceID: sourceID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get run triggers for workspace %s: %w", workspaceName, err)
+	}
+	if t != nil {
+		fmt.Printf("Run trigger %s -> %s is already set\n", sourceName, workspaceName)
+		return nil
+	}
+
+	if pFlags.readOnlyMode {
+		fmt.Printf("(Read-only Mode) Run trigger %s -> %s would be set\n", sourceName, workspaceName)
+		return nil
+	}
+
+	if err := lib.CreateRunTrigger(lib.RunTriggerConfig{
+		WorkspaceID:       workspaceID,
+		SourceWorkspaceID: sourceID,
+	}); err != nil {
+		return fmt.Errorf("create run trigger API error: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
### Added
- Setup Terraform run triggers in the secondary workspaces in a "cascading" configuration.

_Note: this is the same as PR #7 which was closed by GitHub when I deleted the source branch locally. It seems that GitHub can't handle that as well as when a source branch is deleted directly on GitHub._