### PR TITLE
use the correct option string for org-alternate

### DIFF
--- a/cmd/cli/multiregion/multiregion.go
+++ b/cmd/cli/multiregion/multiregion.go
@@ -98,7 +98,7 @@ func getPersistentFlags() PersistentFlags {
 		secondaryRegion: getRequiredParam(flagRegion2),
 		readOnlyMode:    viper.GetBool("read-only-mode"),
 		tfcTokenAlt:     getOption(flagTfcTokenAlternate, ""),
-		orgAlt:          getOption(flagOrgAlternate, viper.GetString("org-alternate")),
+		orgAlt:          getOption(flagOrgAlternate, viper.GetString(flagOrgAlternate)),
 	}
 
 	if pFlags.orgAlt != "" && pFlags.tfcTokenAlt == "" {

--- a/cmd/cli/multiregion/multiregion.go
+++ b/cmd/cli/multiregion/multiregion.go
@@ -98,7 +98,7 @@ func getPersistentFlags() PersistentFlags {
 		secondaryRegion: getRequiredParam(flagRegion2),
 		readOnlyMode:    viper.GetBool("read-only-mode"),
 		tfcTokenAlt:     getOption(flagTfcTokenAlternate, ""),
-		orgAlt:          getOption(flagOrgAlternate, viper.GetString("org")),
+		orgAlt:          getOption(flagOrgAlternate, viper.GetString("org-alternate")),
 	}
 
 	if pFlags.orgAlt != "" && pFlags.tfcTokenAlt == "" {


### PR DESCRIPTION
### Fixed
- Use the correction option string (`org-alternate`) for the org-alternate flag.