### PR TITLE
assorted fixes in the "multiregion dns" command

### DIFF
--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -135,7 +135,7 @@ func (d *DnsCommand) setDnsRecordValues(idpKey string) {
 	}
 
 	for _, record := range dnsRecords {
-		d.setCloudflareCname(record.name, record.value)
+		d.setCloudflareCname(record.name, record.value+"."+d.domainName)
 	}
 }
 

--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -56,6 +56,10 @@ func InitDnsCmd(parentCmd *cobra.Command) {
 func runDnsCommand(failback bool) {
 	pFlags := getPersistentFlags()
 
+	if pFlags.readOnlyMode {
+		fmt.Println("-- Read-only mode enabled --")
+	}
+
 	d := newDnsCommand(pFlags, failback)
 
 	d.setDnsRecordValues(pFlags.idp)

--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -151,10 +151,12 @@ func (d *DnsCommand) setCloudflareCname(name, value string) {
 
 	r, _, err := d.cfClient.ListDNSRecords(ctx, d.cfZone, cloudflare.ListDNSRecordsParams{Name: name + "." + d.domainName})
 	if err != nil {
-		log.Fatalf("error finding DNS record %s: %s", name, err)
+		fmt.Printf("Error: Cloudflare API call failed to find DNS record %s: %s\n", name, err)
+		return
 	}
 	if len(r) != 1 {
-		log.Fatalf("did not find DNS record %s", name)
+		fmt.Printf("Error: did not find DNS record %q in domain %q\n", name, d.domainName)
+		return
 	}
 
 	if r[0].Content == value {
@@ -179,6 +181,6 @@ func (d *DnsCommand) setCloudflareCname(name, value string) {
 		Content: value,
 	})
 	if err != nil {
-		log.Fatalf("error updating DNS record %s: %s", name, err)
+		fmt.Printf("error updating DNS record %s: %s\nparams: %+v\n", name, err, params)
 	}
 }

--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -129,8 +129,6 @@ func (d *DnsCommand) setDnsRecordValues(idpKey string) {
 		{supportBotName, supportBotName + "-" + region},
 
 		// ECS services
-		{idpKey + "-email", idpKey + "-email-" + region},
-		{idpKey + "-broker", idpKey + "-broker-" + region},
 		{idpKey + "-pw-api", idpKey + "-pw-api-" + region},
 		{idpKey, idpKey + "-" + region},
 		{idpKey + "-sync", idpKey + "-sync-" + region},

--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -179,6 +179,7 @@ func (d *DnsCommand) setCloudflareCname(name, value string) {
 		Type:    "CNAME",
 		Name:    name,
 		Content: value,
+		Comment: r[0].Comment,
 	})
 	if err != nil {
 		fmt.Printf("error updating DNS record %s: %s\n", name, err)

--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -181,6 +181,6 @@ func (d *DnsCommand) setCloudflareCname(name, value string) {
 		Content: value,
 	})
 	if err != nil {
-		fmt.Printf("error updating DNS record %s: %s\nparams: %+v\n", name, err, params)
+		fmt.Printf("error updating DNS record %s: %s\n", name, err)
 	}
 }

--- a/cmd/cli/multiregion/failover.go
+++ b/cmd/cli/multiregion/failover.go
@@ -65,6 +65,10 @@ func InitFailoverCmd(parentCmd *cobra.Command) {
 func runFailover() {
 	pFlags := getPersistentFlags()
 
+	if pFlags.readOnlyMode {
+		fmt.Println("-- Read-only mode enabled --")
+	}
+
 	lib.SetToken(pFlags.tfcToken)
 
 	answer := simplePrompt(`Please confirm activation of failover mode. Type "yes" to continue.`)

--- a/cmd/cli/multiregion/setup.go
+++ b/cmd/cli/multiregion/setup.go
@@ -29,6 +29,10 @@ func InitSetupCmd(parentCmd *cobra.Command) {
 func runSetup() {
 	pFlags := getPersistentFlags()
 
+	if pFlags.readOnlyMode {
+		fmt.Println("-- Read-only mode enabled --")
+	}
+
 	lib.SetToken(pFlags.tfcToken)
 
 	createSecondaryWorkspaces(pFlags)


### PR DESCRIPTION
### Added
- Print a message when running in read-only mode.

### Fixed
- Don't try to set the DNS record for the internal ECS services. We now use direct routing within each zone.
- Don't fail the entire command if one DNS update fails.
- Use the FQDN for the CNAME value.
- Retain the Cloudflare DNS record comment when updating a record.
