### PR TITLE
remove id-sync from the failover dns command

### DIFF
--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -133,7 +133,6 @@ func (d *DnsCommand) setDnsRecordValues(idpKey string) {
 		// ECS services
 		{idpKey + "-pw-api", idpKey + "-pw-api-" + region},
 		{idpKey, idpKey + "-" + region},
-		{idpKey + "-sync", idpKey + "-sync-" + region},
 	}
 
 	common := []nameValuePair{


### PR DESCRIPTION
Since [idp-id-sync](https://github.com/silinternational/idp-id-sync) no longer has an API as of version 5.0.0, its DNS record needs to be removed from the `failover dns` command.