### PR TITLE
Release 0.4.3 -- Version patch

### DIFF
--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -23,6 +23,7 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if version != "" {
 			fmt.Printf("Version %s\n", version)
+			return
 		}
 
 		buildInfo, ok := debug.ReadBuildInfo()

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -22,13 +23,13 @@ var versionCmd = &cobra.Command{
 	Short: "Show idp-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
 		if version != "" {
-			fmt.Printf("Version %s\n", version)
+			fmt.Println("Version:", version)
 			return
 		}
 
 		buildInfo, ok := debug.ReadBuildInfo()
 		if ok {
-			fmt.Println("Version:", buildInfo.Main.Version)
+			fmt.Println("Version:", strings.TrimLeft(buildInfo.Main.Version, "v"))
 			return
 		}
 


### PR DESCRIPTION

### Fixed
- Fixed duplicate display of version number
- Removed the "v" from the version number since it's preceded by the word "version"

---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
