### PR TITLE
upgrade GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -20,12 +20,12 @@ jobs:
       run: git fetch --force --tags
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
 
     - name: Run GoReleaser in snapshot mode
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v7
       if: github.event.pull_request
       with:
         version: latest
@@ -34,7 +34,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run GoReleaser on a release tag
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v7
       if: startsWith(github.ref, 'refs/tags/')
       with:
         version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,14 @@
 # This is the configuration for goreleaser
-# Check the documentation at http://goreleaser.com for details
+# Check the documentation at https://goreleaser.com for details
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
 before:
   hooks:
     - go mod tidy
+
 builds:
   - id: idp-cli
     binary: idp-cli
@@ -25,19 +31,24 @@ builds:
 gomod:
   proxy: true
 archives:
-  -
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
-      idp-cli_
+      {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-dev"
+  version_template: "{{ .Tag }}-dev"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update actions version references to latest available to include support for Node 24.